### PR TITLE
Wdp191203 4

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -48,9 +48,7 @@ const ProductBox = ({ name, price, promo, stars, image }) => (
         </Button>
       </div>
       <div className={styles.price}>
-        <Button noHover variant='small'>
-          $ {price}
-        </Button>
+        <Button noHover>$ {price}</Button>
       </div>
     </div>
   </div>

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -5,6 +5,12 @@
   border: 1px solid #e1e1e1;
   margin-bottom: 2rem;
 
+  &:hover {
+    .photo .buttons {
+      display: flex;
+    }
+  }
+
   .photo {
     position: relative;
     padding: 80% 10px 0 10px;
@@ -39,8 +45,10 @@
     }
 
     .buttons {
-      display: flex;
+      display: none;
       justify-content: space-between;
+      position: absolute;
+      bottom: 0;
     }
   }
 

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -1,4 +1,5 @@
 @import "../../../styles/settings.scss";
+@import "../Button/Button.module.scss";
 
 .root {
   background-color: #ffffff;
@@ -8,6 +9,9 @@
   &:hover {
     .photo .buttons {
       display: flex;
+    }
+    .price {
+      background-color: $primary;
     }
   }
 
@@ -92,5 +96,9 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+
+  .price {
+    @extend .small;
   }
 }


### PR DESCRIPTION
**Opis problemu:**
Buttony "Quick view" oraz "Add to cart" powinny być widoczne tylko na hover całego boksa z produktem. Wtedy też powinno zmieniać się tło ceny. 

**Rozwiązanie problemu:**
Dodano pojawianie się "buttons" po hover na root.
Stworzono w root selektor price, zaimportowano tam właściwości variantu small komponentu button oraz dodano zmianę tła po hover na root.