### PR TITLE
WDP191203-17

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -67,7 +67,7 @@ class NewFurniture extends React.Component {
           </div>
           <div className='row'>
             {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
-              <div key={item.id} className='col-3'>
+              <div key={item.id} className='col-12 col-md-6 col-lg-3'>
                 <ProductBox {...item} />
               </div>
             ))}


### PR DESCRIPTION
**Opis problemu:**
Sekcja New Furniture na tabletach miała mieć po 2-3 elementy w rzędzie, a na mobilkach 1-2 w rzędzie. Do zrobienia trzy warianty: desktop, tablet i mobile.

**Rozwiązanie problemu:**
Wprowadzenie rozmiarów na tablet i mobile w New Furniture w divie wrappującym Product box
